### PR TITLE
Fix set property method not working when key is an object

### DIFF
--- a/app/lib/setProperty.js
+++ b/app/lib/setProperty.js
@@ -9,8 +9,13 @@ const setProperty = (sourceObject, keyPath, replacementKey, result = {}) => {
                 result[key] = sourceObject[key];
             }
         } else {
-            result[key] = {};
-            setProperty(sourceObject[key], keyPath.slice(1), replacementKey, result[key]);
+            if (key == currentKeyToReplace && keyPath.length == 1) {
+                result[replacementKey] = sourceObject[key];
+            } else {
+                result[key] = {};
+                setProperty(sourceObject[key], keyPath.slice(1), replacementKey, result[key]);
+            }
+            
         }
     }
 


### PR DESCRIPTION
Fixing set property when the replacement key is an object not being detected